### PR TITLE
Stage > Main

### DIFF
--- a/clients/client-topia/src/controllers/DroppedAsset.ts
+++ b/clients/client-topia/src/controllers/DroppedAsset.ts
@@ -343,6 +343,23 @@ export class DroppedAsset extends Asset implements DroppedAssetInterface {
 
   /**
    * @summary
+   * Updates webhook zone options for a dropped asset.
+   *
+   * @usage
+   * ```ts
+   * await droppedAsset.updateWebhookZone(true);
+   * ```
+   */
+  updateWebhookZone(isWebhookZoneEnabled: boolean): Promise<void | ResponseType> {
+    try {
+      return this.#updateDroppedAsset({ isWebhookZoneEnabled }, "set-webhook-zone");
+    } catch (error) {
+      throw this.errorHandler({ error });
+    }
+  }
+
+  /**
+   * @summary
    * Moves a dropped asset to specified coordinates.
    *
    * @usage
@@ -364,7 +381,7 @@ export class DroppedAsset extends Asset implements DroppedAssetInterface {
    *
    * @usage
    * ```ts
-   * await droppedAsset.updateMuteZone({
+   * await droppedAsset.updatePrivateZone({
    *   "isPrivateZone": false,
    *   "isPrivateZoneChatDisabled": true,
    *   "privateZoneUserCap": 10
@@ -470,9 +487,9 @@ export class DroppedAsset extends Asset implements DroppedAssetInterface {
     title: string;
     type: string;
     url: string;
-  }): Promise<void | ResponseType> {
+  }): Promise<void | AxiosResponse> {
     try {
-      await this.topiaPublicApi().post(
+      const response = await this.topiaPublicApi().post(
         `/world/${this.urlSlug}/webhooks`,
         {
           active: true,
@@ -488,6 +505,7 @@ export class DroppedAsset extends Asset implements DroppedAssetInterface {
         },
         this.requestOptions,
       );
+      return response.data.webhookId;
     } catch (error) {
       throw this.errorHandler({ error });
     }

--- a/clients/client-topia/src/controllers/World.ts
+++ b/clients/client-topia/src/controllers/World.ts
@@ -130,7 +130,6 @@ export class World extends SDKController implements WorldInterface {
       // create temp map and then update private property only once
       const tempDroppedAssetsMap: { [key: string]: DroppedAsset } = {};
       for (const index in response.data) {
-        // tempDroppedAssetsMap[id] = createDroppedAsset(this.apiKey, response.data[id], this.urlSlug);
         tempDroppedAssetsMap[index] = new DroppedAsset(this.topia, response.data[index].id, this.urlSlug, {
           attributes: response.data[index],
           credentials: this.credentials,

--- a/clients/client-topia/src/index.ts
+++ b/clients/client-topia/src/index.ts
@@ -8,6 +8,7 @@ export {
   WorldActivityFactory,
   WorldFactory,
 } from "factories";
+export * from "types";
 
 Error.stackTraceLimit = 20;
 process.on("unhandledRejection", (reason: any) => {

--- a/clients/client-topia/src/types/ResponseTypes.ts
+++ b/clients/client-topia/src/types/ResponseTypes.ts
@@ -1,4 +1,4 @@
 export type ResponseType = {
-  success: boolean;
   message: string;
+  success: boolean;
 };


### PR DESCRIPTION
Breaking changes:
`World.replaceScene` now returns `{ success: true }` instead of "success"
`World.dropScene` now returns` { success: true }` instead of "success"
`DroppedAsset.deleteDroppedAsset` now returns` { success: true }` instead of "success"
`World.updateDetails` now returns `{ success: true }` instead of "Success"

New and Updated Features:
New method, `DroppedAsset.updateWebhookZone`, allows user to set `isWebhookZoneEnabled` for a dropped asset e.g. `droppedAsset.updateWebhookZone(true)`
`DroppedAsset.updateClickType`  now accepts `"clickType": "webhook"`