### PR TITLE
feat: NPC voice sessions and configurable spawn effects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,9 +416,52 @@ Format: {publicKey}|{inventoryItemId}|{userInventoryItemId}
 
 This allows the frontend to route NPCs to `NpcSystem` instead of `PlayerSpriteSystem`.
 
+### NPC Spawn Effects
+
+`createNpc` accepts a `spawnEffect` config for custom portal animations:
+
+```typescript
+interface SpawnEffectConfig {
+  type?: "portal" | "none";   // "portal" = animated vortex (default), "none" = instant
+  colors?: number[];           // Sector colors (cycles if fewer than sectorCount)
+  glowColor?: number;          // Outer glow hex
+  glowOpacity?: number;        // 0-1
+  centerColor?: number;        // Center dot hex
+  duration?: number;           // Total ms (100-10000)
+  sectorCount?: number;        // Pie slices (2-32)
+  gridSize?: number;           // Dissolve grid NxN (2-50)
+}
+
+const npc = await visitor.createNpc(itemId, {
+  stationary: true,
+  replace: true,
+  spawnEffect: { type: "portal", colors: [0x8b00ff, 0x1a0029] },
+});
+```
+
+### AI NPC Voice Sessions
+
+SDK apps can attach AI-powered voice chat to NPCs:
+
+```typescript
+// Start voice session
+await visitor.startNpcVoiceSession({
+  ephemeralKey: "ek_...",      // From OpenAI Realtime Sessions API
+  voice: "alloy",              // OpenAI voice ID
+  instructions: "...",         // System prompt + curriculum
+  model: "gpt-4o-realtime-preview",
+});
+
+// Stop voice session
+await visitor.stopNpcVoiceSession();
+```
+
+**Key interfaces:** `NpcVoiceConfigInterface`, `SpawnEffectConfig`, `CreateNpcOptions` in `interfaces/VisitorInterfaces.ts`
+
 ### Related Documentation
 
-See `npcs.md` in the topia-stack root for full NPC architecture documentation.
+See `docs/claude/npc-voice-chat.md` in topia-stack for full feature documentation.
+See `docs/claude/npcs.md` in topia-stack for NPC architecture.
 
 ---
 

--- a/clients/client-topia/src/controllers/Visitor.ts
+++ b/clients/client-topia/src/controllers/Visitor.ts
@@ -9,6 +9,7 @@ import {
   FireToastInterface,
   InventoryItemInterface,
   MoveVisitorInterface,
+  NpcVoiceConfigInterface,
   OpenIframeInterface,
   UserInventoryItemInterface,
   VisitorInterface,
@@ -822,6 +823,88 @@ export class Visitor extends User implements VisitorInterface {
       await this.topiaPublicApi().delete(`/world/${this.urlSlug}/visitors/${this.id}/delete-npc`, this.requestOptions);
     } catch (error) {
       throw this.errorHandler({ error, sdkMethod: "Visitor.deleteNpc" });
+    }
+  }
+
+  /**
+   * Start an AI-powered voice session for this visitor's NPC.
+   *
+   * @remarks
+   * Establishes a real-time voice connection between the visitor and an AI backend
+   * (currently OpenAI Realtime API) through the NPC. The NPC must already be spawned
+   * via `createNpc()` before calling this method.
+   *
+   * The voice session occupies a video slot in the visitor's peer video grid, showing
+   * the NPC's avatar image. Audio streams bidirectionally between the visitor's microphone
+   * and the AI. The session is private — only the NPC's owner hears the AI.
+   *
+   * Only one AI voice session is allowed per visitor per world (across all apps).
+   *
+   * @keywords voice, ai, npc, chat, audio, realtime, speech, assistant, tutor
+   *
+   * @category NPCs
+   *
+   * @param config - Voice session configuration including ephemeral key and instructions.
+   *
+   * @example
+   * ```ts
+   * // Generate ephemeral key on your backend first
+   * const ephemeralKey = await generateOpenAIEphemeralKey();
+   *
+   * await visitor.startNpcVoiceSession({
+   *   ephemeralKey,
+   *   voice: "alloy",
+   *   instructions: "You are a friendly science tutor helping with photosynthesis.",
+   * });
+   * ```
+   *
+   * @returns {Promise<void | ResponseType>} Returns `{ success: true }` or an error.
+   */
+  async startNpcVoiceSession(config: NpcVoiceConfigInterface): Promise<void | ResponseType> {
+    const params = { voiceConfig: config };
+    try {
+      const response = await this.topiaPublicApi().put(
+        `/world/${this.urlSlug}/visitors/${this.id}/start-npc-voice-session`,
+        params,
+        this.requestOptions,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.errorHandler({ error, params, sdkMethod: "Visitor.startNpcVoiceSession" });
+    }
+  }
+
+  /**
+   * Stop the active AI voice session for this visitor's NPC.
+   *
+   * @remarks
+   * Tears down the real-time voice connection. The NPC remains in the world
+   * but no longer has voice capabilities. The video slot is released.
+   *
+   * This is idempotent — calling it when no voice session is active succeeds silently.
+   * Note: Deleting the NPC via `deleteNpc()` also stops the voice session automatically.
+   *
+   * @keywords stop, end, voice, ai, npc, disconnect, hangup
+   *
+   * @category NPCs
+   *
+   * @example
+   * ```ts
+   * await visitor.stopNpcVoiceSession();
+   * ```
+   *
+   * @returns {Promise<void | ResponseType>} Returns `{ success: true }` or an error.
+   */
+  async stopNpcVoiceSession(): Promise<void | ResponseType> {
+    try {
+      const response = await this.topiaPublicApi().put(
+        `/world/${this.urlSlug}/visitors/${this.id}/stop-npc-voice-session`,
+        {},
+        this.requestOptions,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.errorHandler({ error, sdkMethod: "Visitor.stopNpcVoiceSession" });
     }
   }
 

--- a/clients/client-topia/src/interfaces/VisitorInterfaces.ts
+++ b/clients/client-topia/src/interfaces/VisitorInterfaces.ts
@@ -24,6 +24,8 @@ export interface VisitorInterface extends SDKInterface {
   createNpc(userInventoryItemId: string, options?: { showNameplate?: boolean }): Promise<Visitor>;
   deleteNpc(): Promise<void>;
   getNpc(): Promise<Visitor | null>;
+  startNpcVoiceSession(config: NpcVoiceConfigInterface): Promise<void | ResponseType>;
+  stopNpcVoiceSession(): Promise<void | ResponseType>;
 
   triggerParticle({
     id,
@@ -88,4 +90,22 @@ export interface OpenIframeInterface {
   link: string;
   shouldOpenInDrawer?: boolean;
   title?: string;
+}
+
+export interface NpcVoiceConfigInterface {
+  /** OpenAI ephemeral key (ek_*). Generated server-side, used once to establish WebRTC connection. */
+  ephemeralKey: string;
+  /** OpenAI voice ID (e.g., "alloy", "echo", "shimmer"). */
+  voice: string;
+  /** System prompt including curriculum context and behavioral instructions. */
+  instructions: string;
+  /** OpenAI model ID. Defaults to "gpt-4o-realtime-preview". */
+  model?: string;
+  /** Voice activity detection configuration. */
+  turnDetection?: {
+    type: "server_vad";
+    threshold?: number;
+    prefix_padding_ms?: number;
+    silence_duration_ms?: number;
+  };
 }

--- a/clients/client-topia/src/interfaces/VisitorInterfaces.ts
+++ b/clients/client-topia/src/interfaces/VisitorInterfaces.ts
@@ -21,7 +21,7 @@ export interface VisitorInterface extends SDKInterface {
     quantity: number,
   ): Promise<UserInventoryItem>;
   fetchInventoryItem(item: InventoryItemInterface): Promise<UserInventoryItem>;
-  createNpc(userInventoryItemId: string, options?: { showNameplate?: boolean }): Promise<Visitor>;
+  createNpc(userInventoryItemId: string, options?: CreateNpcOptions): Promise<Visitor>;
   deleteNpc(): Promise<void>;
   getNpc(): Promise<Visitor | null>;
   startNpcVoiceSession(config: NpcVoiceConfigInterface): Promise<void | ResponseType>;
@@ -90,6 +90,24 @@ export interface OpenIframeInterface {
   link: string;
   shouldOpenInDrawer?: boolean;
   title?: string;
+}
+
+export interface SpawnEffectConfig {
+  type?: "portal" | "none";
+  colors?: number[];
+  glowColor?: number;
+  glowOpacity?: number;
+  centerColor?: number;
+  duration?: number;
+  sectorCount?: number;
+  gridSize?: number;
+}
+
+export interface CreateNpcOptions {
+  showNameplate?: boolean;
+  stationary?: boolean;
+  replace?: boolean;
+  spawnEffect?: SpawnEffectConfig;
 }
 
 export interface NpcVoiceConfigInterface {


### PR DESCRIPTION
## Summary

- **Voice Session Methods**: `visitor.startNpcVoiceSession(config)` and `visitor.stopNpcVoiceSession()` — PUT endpoints for AI-powered voice chat on NPCs. Config includes ephemeral key, voice ID, instructions, model, and VAD settings.
- **Spawn Effect Config**: `createNpc` options now accept `spawnEffect` (portal animation config), `stationary` (NPC stays in place vs follows), and `replace` (clean up existing NPC before creating new one).
- **TypeScript Interfaces**: `NpcVoiceConfigInterface`, `SpawnEffectConfig`, updated `CreateNpcOptions` in `VisitorInterfaces.ts`.

## Test plan

- [ ] `visitor.startNpcVoiceSession({ ephemeralKey, voice, instructions })` → verify PUT sent with correct payload
- [ ] `visitor.stopNpcVoiceSession()` → verify PUT sent
- [ ] `visitor.createNpc(id, { spawnEffect: { type: "portal" } })` → verify spawnEffect in POST body
- [ ] `visitor.createNpc(id, { stationary: true, replace: true })` → verify flags in POST body
- [ ] TypeScript: `npx tsc --noEmit` passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)