### PR TITLE
fix: throw proper Errors instead of bare strings, warn on missing profileId

### DIFF
--- a/clients/client-topia/src/controllers/SDKController.ts
+++ b/clients/client-topia/src/controllers/SDKController.ts
@@ -183,6 +183,10 @@ export abstract class SDKController implements SDKInterface {
     } else if (error instanceof Error) {
       errorMessage = error?.message || message;
       stack = `${error.stack}\n${stackTrace.stack}`;
+    } else if (error !== undefined && error !== null) {
+      // Handle bare string throws and other non-Error types
+      errorMessage = typeof error === "string" ? error : JSON.stringify(error);
+      stack = stackTrace.stack || "empty";
     }
 
     return {

--- a/clients/client-topia/src/controllers/User.ts
+++ b/clients/client-topia/src/controllers/User.ts
@@ -96,6 +96,16 @@ export class User extends SDKController implements UserInterface {
     super(topia, { profileId: options?.profileId, ...options.credentials });
 
     this.profileId = options?.profileId;
+
+    // Warn devs about common mistake: passing profileId only inside credentials
+    if (!this.profileId && options?.credentials?.profileId) {
+      console.warn(
+        `[@rtsdk/topia] User created without top-level profileId. ` +
+          `You passed profileId inside credentials but not in options. ` +
+          `Methods like grantInventoryItem will fail. ` +
+          `Fix: User.create({ profileId: "${options.credentials.profileId}", credentials: { ... } })`,
+      );
+    }
     this.dataObject = {};
     this.profile = {};
 
@@ -625,7 +635,7 @@ export class User extends SDKController implements UserInterface {
    */
   async fetchDataObject(appPublicKey?: string, appJWT?: string): Promise<void | ResponseType> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       let query = "";
       if (appPublicKey) query = `?appPublicKey=${appPublicKey}&appJWT=${appJWT}`;
@@ -675,7 +685,7 @@ export class User extends SDKController implements UserInterface {
     } = {},
   ): Promise<void | ResponseType> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       await this.topiaPublicApi().put(
         `/user/dataObjects/${this.profileId}/set-data-object`,
@@ -722,7 +732,7 @@ export class User extends SDKController implements UserInterface {
     } = {},
   ): Promise<void | ResponseType> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       await this.topiaPublicApi().put(
         `/user/dataObjects/${this.profileId}/update-data-object`,
@@ -787,7 +797,7 @@ export class User extends SDKController implements UserInterface {
    */
   async fetchInventoryItems(): Promise<void> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       const response = await this.topiaPublicApi().get(
         `/user/inventory/${this.profileId}/get-user-inventory-items`,
@@ -828,7 +838,7 @@ export class User extends SDKController implements UserInterface {
    */
   async grantInventoryItem(item: InventoryItemInterface, quantity = 1): Promise<UserInventoryItem> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       const response = await this.topiaPublicApi().put(
         `/user/inventory/${this.profileId}/grant-user-inventory-item`,
@@ -861,7 +871,7 @@ export class User extends SDKController implements UserInterface {
    */
   async modifyInventoryItemQuantity(item: UserInventoryItemInterface, quantity: number): Promise<UserInventoryItem> {
     try {
-      if (!this.profileId) throw "This method requires the use of a profileId";
+      if (!this.profileId) throw new Error("This method requires the use of a profileId. Pass profileId as a top-level option: User.create({ profileId, credentials: { ... } })");
 
       const response = await this.topiaPublicApi().put(
         `/user/inventory/${this.profileId}/update-user-inventory-item-quantity`,


### PR DESCRIPTION
## Summary
- **User constructor warning**: When `profileId` is passed inside `credentials` but not as a top-level option, a `console.warn` now tells the dev exactly what's wrong and how to fix it
- **`throw "string"` → `throw new Error(...)`**: All 6 bare string throws in User.ts now throw real Errors with actionable messages, so `errorHandler` can extract the message and stack trace
- **errorHandler fallback**: Added catch-all branch for non-Error/non-AxiosError throws (bare strings, objects) — prevents the silent "Something went wrong" default that swallows the actual error

## Context
SDK apps calling `User.create({ credentials: { profileId } })` instead of `User.create({ profileId, credentials: { ... } })` would silently fail on any method requiring `profileId` (grantInventoryItem, fetchDataObject, etc.). The thrown string bypassed errorHandler's `instanceof` checks, producing a generic 500 with no useful information.

## Test plan
- [ ] `User.create({ credentials: { profileId: "abc" } })` logs a console.warn with fix instructions
- [ ] `User.create({ profileId: "abc", credentials: { ... } })` works with no warning
- [ ] `user.grantInventoryItem()` without profileId throws Error with clear message (not bare string)
- [ ] Error message includes "Pass profileId as a top-level option" guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)