### PR TITLE
Add Visitor.fetchUserGroupDataObject

### DIFF
--- a/clients/client-topia/src/controllers/Visitor.ts
+++ b/clients/client-topia/src/controllers/Visitor.ts
@@ -43,6 +43,7 @@ AI RULES for code assistants
 
   AVAILABLE METHODS:
     - fetchVisitor(): Retrieves visitor details from the world
+    - fetchUserGroupDataObject(): Gets the world's user group data objects (requires canReceiveUserGroupDataObjects on the public key)
     - fetchDataObject(): Gets visitor's data object
     - setDataObject(dataObject, options?): Sets visitor's entire data object
     - updateDataObject(dataObject, options?): Updates specific fields in visitor data
@@ -130,6 +131,37 @@ export class Visitor extends User implements VisitorInterface {
       if (this.profile?.profileId) this.profileId = this.profile.profileId;
     } catch (error) {
       throw this.errorHandler({ error, sdkMethod: "Visitor.fetchVisitor" });
+    }
+  }
+
+  /**
+   * Get the user group data objects available to this visitor's world.
+   *
+   * The interactive public key must have `canReceiveUserGroupDataObjects` set on it
+   * (granted by the Topia team to first-party SDK apps).
+   *
+   * Mirrors the array delivered as `userGroupDataObjects` in the asset-click webhook
+   * payload (worldUserGroups branch).
+   *
+   * @keywords get, fetch, user group, data object, group
+   *
+   * @example
+   * ```ts
+   * const { userGroupDataObjects } = await visitor.fetchUserGroupDataObject();
+   * ```
+   *
+   * @returns
+   * Returns `{ success: true, userGroupDataObjects: object[] }` or an error.
+   */
+  async fetchUserGroupDataObject(): Promise<void | ResponseType> {
+    try {
+      const response: AxiosResponse = await this.topiaPublicApi().get(
+        `/world/${this.urlSlug}/visitors/${this.id}/user-group-data-object`,
+        this.requestOptions,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.errorHandler({ error, sdkMethod: "Visitor.fetchUserGroupDataObject" });
     }
   }
 

--- a/clients/client-topia/src/controllers/__tests__/visitor.test.ts
+++ b/clients/client-topia/src/controllers/__tests__/visitor.test.ts
@@ -32,6 +32,15 @@ describe("Visitor Class", () => {
     expect(mock.history.get.length).toBe(1);
   });
 
+  it("should fetch user group data objects", async () => {
+    mock
+      .onGet(`https://${apiDomain}/api/v1/world/${urlSlug}/visitors/${id}/user-group-data-object`)
+      .reply(200, { success: true, userGroupDataObjects: [{ foo: "bar" }] });
+    const result = await testVisitor.fetchUserGroupDataObject();
+    expect(mock.history.get.length).toBe(1);
+    expect(result).toEqual({ success: true, userGroupDataObjects: [{ foo: "bar" }] });
+  });
+
   it("should move a list of visitors to uniquely specified coordinates", async () => {
     mock.onPut(`https://${apiDomain}/api/v1/world/${urlSlug}/visitors/${id}/move`).reply(200);
     await testVisitor.moveVisitor({

--- a/clients/client-topia/src/interfaces/VisitorInterfaces.ts
+++ b/clients/client-topia/src/interfaces/VisitorInterfaces.ts
@@ -4,6 +4,7 @@ import { UserInventoryItem, Visitor } from "controllers";
 
 export interface VisitorInterface extends SDKInterface {
   fetchVisitor(): Promise<void | ResponseType>;
+  fetchUserGroupDataObject(): Promise<void | ResponseType>;
   moveVisitor({ shouldTeleportVisitor, x, y }: MoveVisitorInterface): Promise<void | ResponseType>;
   fireToast({ groupId, title, text }: FireToastInterface): Promise<void | ResponseType>;
   openIframe({ link, shouldOpenInDrawer, title }: OpenIframeInterface): Promise<void | ResponseType>;


### PR DESCRIPTION
## Summary
- New `Visitor.fetchUserGroupDataObject()` SDK method that hits `GET /world/:urlSlug/visitors/:visitorId/user-group-data-object` on public-api.
- Returns the same array shape delivered as `userGroupDataObjects` in the asset-click webhook payload, so apps that already parse the webhook can reuse the parser.
- Requires `canReceiveUserGroupDataObjects` on the interactive public key (Topia-controlled flag, granted to first-party SDK apps). The endpoint is also gated server-side via `hasPublicKeyPermissions` — clients without the flag get 403.
- Companion backend PR: topia-io/topia-backend#495.

## Test plan
- [ ] `tsc --noEmit` clean (already verified locally)
- [ ] Once the backend PR is merged to a deployed env, exercise from a doorbell-style SDK app: `await visitor.fetchUserGroupDataObject()` returns `{ success: true, userGroupDataObjects: [...] }` matching the webhook payload
- [ ] Verify error path: SDK app whose key lacks the flag receives a structured 403 error via `errorHandler`
- [ ] yalc-push + link in a test SDK app before any npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)