### PR TITLE
Add visitor.submitGrade — LTI grade passback for SDK apps

### DIFF
--- a/clients/client-topia/src/controllers/Visitor.ts
+++ b/clients/client-topia/src/controllers/Visitor.ts
@@ -12,6 +12,7 @@ import {
   MoveVisitorInterface,
   NpcVoiceConfigInterface,
   OpenIframeInterface,
+  SubmitGradeInterface,
   UserInventoryItemInterface,
   VisitorInterface,
   VisitorOptionalInterface,
@@ -232,6 +233,53 @@ export class Visitor extends User implements VisitorInterface {
       return response.data;
     } catch (error) {
       throw this.errorHandler({ error, params, sdkMethod: "Visitor.fireToast" });
+    }
+  }
+
+  /**
+   * Submit a grade for this visitor to the LMS gradebook (LTI grade passback).
+   *
+   * Requires: the world is an LTI course world, AND the world has explicitly
+   * allowed your app's public key to submit grades
+   * (`controls.gradeSubmissionPublicKeys` — configured per world by the world
+   * owner). Fails with 403 otherwise.
+   *
+   * If the visitor entered the world from a graded LMS assignment, the grade
+   * posts to that assignment's gradebook column. Otherwise a standalone
+   * column is created (once) per `gradeKey` and the grade posts there.
+   * Re-submitting overwrites the visitor's previous score in that column.
+   *
+   * @keywords grade, score, passback, gradebook, LMS, LTI, assignment, submit
+   *
+   * @example
+   * ```ts
+   * await visitor.submitGrade({
+   *   score: 8,
+   *   scoreMaximum: 10,
+   *   gradeKey: "quiz-1",
+   *   label: "Chapter 1 Quiz",
+   * });
+   * ```
+   *
+   * @returns {Promise<void | ResponseType>} Returns `{ success: true, lineitemUrl }` or an error.
+   */
+  async submitGrade({ score, scoreMaximum, gradeKey, label, comment }: SubmitGradeInterface): Promise<void | ResponseType> {
+    const params = {
+      score,
+      scoreMaximum,
+      gradeKey,
+      label,
+      comment,
+    };
+    try {
+      const response = await this.topiaPublicApi().put(
+        `/world/${this.urlSlug}/visitors/${this.id}/submit-grade`,
+        params,
+        this.requestOptions,
+      );
+      return response.data;
+    } catch (error) {
+      throw this.errorHandler({ error, params, sdkMethod: "Visitor.submitGrade" });
     }
   }
 

--- a/clients/client-topia/src/interfaces/SharedInterfaces.ts
+++ b/clients/client-topia/src/interfaces/SharedInterfaces.ts
@@ -3,3 +3,21 @@ export interface FireToastInterface {
   title: string;
   text?: string;
 }
+
+export interface SubmitGradeInterface {
+  /** Points earned by the visitor */
+  score: number;
+  /** Maximum possible points for this grade (must be > 0) */
+  scoreMaximum: number;
+  /**
+   * Stable key for the gradebook column this grade belongs to (e.g. "quiz-1").
+   * Repeat submissions with the same gradeKey update the same column. Ignored
+   * when the visitor entered from a graded LMS assignment — the grade then
+   * goes to that assignment's column automatically.
+   */
+  gradeKey?: string;
+  /** Display name for the gradebook column (defaults to gradeKey) */
+  label?: string;
+  /** Optional comment shown alongside the grade in the LMS */
+  comment?: string;
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — pending E2E verification (see topia-backend#653)

## Summary

`visitor.submitGrade({ score, scoreMaximum, gradeKey?, label?, comment? })` — SDK apps submit a grade for the visitor, landing in the LMS gradebook via LTI AGS.

- Requires an LTI course world that has allowed the app's public key to submit grades (`controls.gradeSubmissionPublicKeys` — world-settings toggle or auto-granted by classroom setup).
- Entered from a graded LMS assignment → the grade posts to that assignment's gradebook column; otherwise a standalone column is created once per `gradeKey`. Re-submission overwrites the visitor's previous score.
- Errors surface LMS-side failures with useful messages (403 not-allowed, 404 no enrollment, 409 no AGS endpoint captured yet).

Companion to [topia-backend#653](https://github.com/topia-io/topia-backend/pull/653) and [topia-frontend#1969](https://github.com/topia-io/topia-frontend/pull/1969).

Note: opened against `main` (this repo's active branch) — `stage` here is 48 commits behind `main` and a stage-based PR would bundle unrelated history.

## Test plan
- `yarn build` clean (tsc + rollup, ESM/CJS/types).
- E2E pending: yalc-link into sdk-quiz and post a real grade to a Schoology gradebook (tracked on the backend PR).
- Do NOT publish to npm until E2E passes and per publishing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)